### PR TITLE
Allow nonce to be set to an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -549,7 +549,7 @@ Auth0.prototype.parseHash = function (hash, options) {
 
     var nonce;
 
-    if (options.nonce) {
+    if (typeof options.nonce !== 'undefined') {
       nonce = options.nonce;
     } else if (window.localStorage) {
       try {


### PR DESCRIPTION
This allows us to work around the case where we know we don't want to use a nonce and storage is unavailable.